### PR TITLE
Update homework schema field names

### DIFF
--- a/app/api/homework.py
+++ b/app/api/homework.py
@@ -52,10 +52,10 @@ def update_homework_type(
     if not homework_type or homework_type.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="권한이 없습니다.")
 
-    homework_type.name = req.name
+    homework_type.title = req.title
     homework_type.description = req.description
-    homework_type.repeat_type = req.repeat_type
-    homework_type.repeat_count = req.repeat_count
+    homework_type.reset_type = req.reset_type
+    homework_type.clear_count = req.clear_count
 
     db.commit()
     return {"message": "숙제가 수정되었습니다."}

--- a/app/crud/homework.py
+++ b/app/crud/homework.py
@@ -5,7 +5,9 @@ from app.schemas.homework import HomeworkTypeCreate
 def create_homework_type(user_id: int, data: HomeworkTypeCreate, db: Session):
     new_homework = HomeworkType(
         user_id=user_id,
-        name=data.name,
+        title=data.title,
+        description=data.description,
+        reset_type=data.reset_type,
         reset_time=data.reset_time,
         clear_count=data.clear_count,
     )

--- a/app/schemas/homework.py
+++ b/app/schemas/homework.py
@@ -31,10 +31,10 @@ class HomeworkSelectableResponse(BaseModel):
     clear_count: int
 
 class HomeworkTypeUpdateRequest(BaseModel):
-    name: constr(min_length=1)
+    title: constr(min_length=1)
     description: str | None = None
-    repeat_type: constr(min_length=1)
-    repeat_count: conint(ge=1)
+    reset_type: constr(min_length=1)
+    clear_count: conint(ge=1)
 
 class HomeworkTypeDetailResponse(BaseModel):
     id: int


### PR DESCRIPTION
## Summary
- use updated field names (`title`, `reset_type`, `clear_count`) in homework CRUD/API and schemas

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846a36920b4832aa6feeb126e9b8661