### PR TITLE
Fix Base usage in models

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,6 @@
 # app/core/config.py
 
 from pydantic_settings import BaseSettings
-from sqlalchemy.orm import declarative_base
 
 class Settings(BaseSettings):
     database_url: str
@@ -14,6 +13,4 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-# 베이스 클래스
-Base = declarative_base()
 

--- a/app/models/character.py
+++ b/app/models/character.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean, func
 from sqlalchemy.orm import relationship
 from datetime import datetime
-from app.core.config import Base
+from app.core.database import Base
 
 
 class Character(Base):

--- a/app/models/homework.py
+++ b/app/models/homework.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, String, Time, ForeignKey, DateTime, Bool
 from sqlalchemy.orm import relationship
 from datetime import time, datetime
 
-from app.core.config import Base
+from app.core.database import Base
 
 class HomeworkType(Base):
     __tablename__ = "homework_types"

--- a/create_db.py
+++ b/create_db.py
@@ -1,7 +1,6 @@
 # create_db.py
 
-from app.core.config import Base
-from app.core.database import engine
+from app.core.database import Base, engine
 from app.models.user import User
 from app.models.character import Character
 from app.models.homework import HomeworkType, CharacterHomework


### PR DESCRIPTION
## Summary
- remove `Base` definition from `config`
- rely on `Base` from `database` in models and DB creation script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a36ac1bc832a9ba696eee0235758