### PR TITLE
Fix duplicate order assignment

### DIFF
--- a/app/api/character.py
+++ b/app/api/character.py
@@ -119,7 +119,6 @@ def update_character_order(
         character = db.query(Character).filter_by(id=update.id, user_id=user.id).first()
         if character:
             character.order = update.order
-            character.order = update.order
             db.add(character)
     db.commit()
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- remove duplicate assignment when updating character order

## Testing
- `python3 -m py_compile app/api/character.py`


------
https://chatgpt.com/codex/tasks/task_e_6846a36b7b94832a8ba95304a6ee3538