### PR TITLE
Add user emails to friend request listings

### DIFF
--- a/app/schemas/friend.py
+++ b/app/schemas/friend.py
@@ -18,6 +18,8 @@ class FriendRequestResponse(BaseModel):
     id: int
     from_user_id: int
     to_user_id: int
+    from_user_email: str | None = None
+    to_user_email: str | None = None
     status: FriendRequestStatus
     created_at: datetime
     updated_at: datetime


### PR DESCRIPTION
## Summary
- include optional email fields in `FriendRequestResponse`
- expose sender/receiver emails in friend request service methods

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684784fffecc832aa80c19294a1a94b1